### PR TITLE
refactor: Migrate Sass syntax

### DIFF
--- a/src/assets/style/global.sass
+++ b/src/assets/style/global.sass
@@ -1,7 +1,7 @@
 // ToDo: Use async load for webfont
+@use './media.sass'
 @import url('https://fonts.googleapis.com/css2?family=Questrial&display=swap')
 @import url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css')
-@import './media.sass'
   
 *
   font-family: Questrial, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Helvetica Neue', Arial, '游ゴシック', 'Yu Gothic', '游ゴシック体', 'YuGothic', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', 'MS P Gothic', sans-serif
@@ -49,7 +49,7 @@ p
 .main-with-margin
   margin: 80px 50px 50px
 
-  @include rmq()
+  @include media.rmq()
     margin: 50px 25px 25px
 
 .doc
@@ -61,7 +61,7 @@ p
     max-width: 700px
     margin: 60px auto
 
-    @include rmq()
+    @include media.rmq()
       width: calc(100vw - 25px * 2)
 
   .header
@@ -96,7 +96,7 @@ p
       max-width: 700px
       margin: 15px auto
 
-      @include rmq()
+      @include media.rmq()
         width: calc(100vw - 25px * 2)
 
       &:has(.image-box, .youtube-embed)
@@ -106,7 +106,7 @@ p
     .image-box, .youtube-embed
       margin: 40px auto
 
-      @include rmq()
+      @include media.rmq()
         margin: 30px 0
 
     h2
@@ -134,7 +134,7 @@ p
       padding: 20px 30px
       box-sizing: border-box
 
-      @include rmq()
+      @include media.rmq()
         margin: 30px 25px
 
       *

--- a/src/assets/style/media.sass
+++ b/src/assets/style/media.sass
@@ -1,13 +1,15 @@
+@use "sass:map";
+
 $breakpoints: ("sm": "screen and (min-width: 400px)", "md": "screen and (min-width: 768px)", "lg": "screen and (min-width: 1000px)", "xl": "screen and (min-width: 1200px)") !default
 
 $Rbreakpoints: ("sm": "screen and (max-width: 400px)", "md": "screen and (max-width: 768px)", "lg": "screen and (max-width: 1000px)", "xl": "screen and (max-width: 1200px)") !default
 
 =mq($breakpoint: md)
-  @media #{map-get($breakpoints, $breakpoint)}
+  @media #{map.get($breakpoints, $breakpoint)}
     @content
 
 =rmq($breakpoint: md)
-  @media #{map-get($Rbreakpoints, $breakpoint)}
+  @media #{map.get($Rbreakpoints, $breakpoint)}
     @content
 
 +mq(md)

--- a/src/components/ContentList.vue
+++ b/src/components/ContentList.vue
@@ -114,14 +114,14 @@ export default class ContentList extends Vue {
 
 <style lang="sass" scoped>
 @use 'sass:math'
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 
 .list-container
   display: grid
   grid-gap: 50px
   grid-template-columns: 100%
 
-  +mq
+  +media.mq
     grid-template-columns: repeat(auto-fill, minmax(25vw, 1fr))
 
   &.mode-events > .item .thumbnail::after

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -50,7 +50,7 @@ export default class TheHeader extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '~/assets/style/media.sass';
+@use '~/assets/style/media.sass';
 
 .header {
   display: grid;
@@ -60,7 +60,7 @@ export default class TheHeader extends Vue {
   width: calc(100vw - 50px * 2);
   margin: 50px auto;
 
-  @include rmq() {
+  @include media.rmq() {
     display: block;
     width: calc(100vw - 25px * 2);
   }
@@ -74,7 +74,7 @@ export default class TheHeader extends Vue {
     width: 200px;
     transform: translateY(7px);
 
-    @include rmq() {
+    @include media.rmq() {
       display: block;
     }
   }
@@ -82,7 +82,7 @@ export default class TheHeader extends Vue {
   .menu {
     display: inline-flex;
 
-    @include rmq() {
+    @include media.rmq() {
       margin-top: 30px;
     }
 
@@ -118,7 +118,7 @@ export default class TheHeader extends Vue {
     .social {
       flex: 0 0 auto;
 
-      @include rmq() {
+      @include media.rmq() {
         display: none;
       }
 

--- a/src/components/layouts/default.vue
+++ b/src/components/layouts/default.vue
@@ -8,5 +8,5 @@
 </template>
 
 <style lang="sass" scoped>
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 </style>

--- a/src/components/layouts/error.vue
+++ b/src/components/layouts/error.vue
@@ -16,5 +16,5 @@ export default class ErrorPage extends Vue {
 </script>
 
 <style lang="sass" scoped>
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 </style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -10,5 +10,5 @@
 
 TheFooter
 <style lang="sass" scoped>
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 </style>

--- a/src/layouts/error.vue
+++ b/src/layouts/error.vue
@@ -25,7 +25,7 @@ export default class ErrorPage extends Vue {
 </script>
 
 <style lang="sass" scoped>
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 
 main
   text-align: center

--- a/src/pages/events/_id.vue
+++ b/src/pages/events/_id.vue
@@ -211,7 +211,7 @@ export default class EventPage extends Vue {
 </script>
 
 <style lang="sass" scoped>
-@import '~assets/style/media.sass'
+@use '~assets/style/media.sass'
 
 .toc
   a
@@ -253,7 +253,7 @@ export default class EventPage extends Vue {
     grid-gap: 50px
     margin: 30px 0
 
-    @include rmq()
+    @include media.rmq()
       grid-template-columns: 1fr
       grid-gap: 15px
 

--- a/src/pages/news/index.vue
+++ b/src/pages/news/index.vue
@@ -80,8 +80,7 @@ export default class NewsIndexPage extends Vue {
 </script>
 
 <style lang="sass" scoped>
-
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 
 .link-list
   padding: 0
@@ -102,7 +101,7 @@ export default class NewsIndexPage extends Vue {
       padding: 20px 30px
       color: inherit
 
-      +rmq
+      +media.rmq
         display: block
         padding: 20px 15px
 

--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -68,7 +68,7 @@ export default class ProfilePage extends Vue {
 
 <style lang="sass" scoped>
 
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 
 .profile
   font-size: 13px

--- a/src/pages/works/_id.vue
+++ b/src/pages/works/_id.vue
@@ -127,7 +127,7 @@ export default class WorkPage extends Vue {
 
 <style lang="sass">
 
-@import '~/assets/style/media.sass'
+@use '~/assets/style/media.sass'
 
 .main
 
@@ -136,7 +136,7 @@ export default class WorkPage extends Vue {
     margin-bottom: 15px
     border-radius: 20px
 
-    @include mq(md)
+    @include media.mq(md)
       margin-top: 85px
       margin-bottom: 85px
 
@@ -148,7 +148,7 @@ export default class WorkPage extends Vue {
     line-height: 1.8em
     color: #888
 
-    @include rmq()
+    @include media.rmq()
       width: calc(100vw - 25px * 2)
 
     .text


### PR DESCRIPTION
Due to deprecation of `@import`, we migrate `@use` and scoped mixins.